### PR TITLE
Add file size metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A fluent plugin that instruments metrics from records and exposes them via web i
 ## Requirements
 
 | fluent-plugin-prometheus | fluentd    | ruby   |
-|--------------------------|------------|--------|
+| ------------------------ | ---------- | ------ |
 | 1.x.y                    | >= v0.14.8 | >= 2.1 |
 | 0.x.y                    | >= v0.12.0 | >= 1.9 |
 
@@ -146,6 +146,8 @@ This plugin uses internal class of Fluentd, so it's easy to break.
 
 - `fluentd_tail_file_position`
     - Current bytes which plugin reads from the file
+- `fluentd_tail_file_size`
+    - Maximin bytes of the file
 - `fluentd_tail_file_inode`
     - inode of the file
 

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -83,7 +83,9 @@ module Fluent::Plugin
           label = labels(info, watcher.path)
           @metrics[:inode].set(label, pe.read_inode)
           @metrics[:position].set(label, pe.read_pos)
-          @metrics[:size].set(label, pe.read_size)
+          if defined?(pe.read_size)
+            @metrics[:size].set(label, pe.read_size)
+          end
         end
       end
     end

--- a/lib/fluent/plugin/in_prometheus_tail_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_tail_monitor.rb
@@ -53,6 +53,9 @@ module Fluent::Plugin
         position: @registry.gauge(
           :fluentd_tail_file_position,
           'Current position of file.'),
+        size: @registry.gauge(
+          :fluentd_tail_file_size,
+          'Size of file.'),
         inode: @registry.gauge(
           :fluentd_tail_file_inode,
           'Current inode of file.'),
@@ -80,6 +83,7 @@ module Fluent::Plugin
           label = labels(info, watcher.path)
           @metrics[:inode].set(label, pe.read_inode)
           @metrics[:position].set(label, pe.read_pos)
+          @metrics[:size].set(label, pe.read_size)
         end
       end
     end

--- a/spec/fluent/plugin/in_prometheus_tail_monitor_spec.rb
+++ b/spec/fluent/plugin/in_prometheus_tail_monitor_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'fluent/test/driver/input'
+require 'fluent/plugin/in_prometheus_tail_monitor'
+
+describe Fluent::Plugin::PrometheusTailMonitorInput do
+  MONITOR_CONFIG = %[
+  @type prometheus_tail_monitor
+]
+
+  describe '#configure' do
+    before :all do
+      @config = MONITOR_CONFIG
+      @driver = Fluent::Test::Driver::Input.new(Fluent::Plugin::PrometheusTailMonitorInput).configure(@config) 
+      @registry= ::Prometheus::Client.registry
+      @driver.run() 
+    end
+
+    describe 'valid' do
+      it 'does not raise error' do
+        expect{@driver}.not_to raise_error
+      end
+    end
+
+    context 'standard config' do
+
+      it 'should contains fluentd_tail_file_inode' do
+        name = "fluentd_tail_file_inode".to_sym
+        expect(@registry.metrics.map(&:name)).to include(name)
+      end
+
+      it 'should contains fluentd_tail_file_position' do
+        name = "fluentd_tail_file_position".to_sym
+        expect(@registry.metrics.map(&:name)).to include(name)
+      end
+
+      it 'should contains fluentd_tail_file_size' do
+        name = "fluentd_tail_file_size".to_sym
+        expect(@registry.metrics.map(&:name)).to include(name)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Based on https://github.com/rewiko/fluentd/pull/2, this PR will expose the size for each log file, to be able to monitor the delay by comparing fluentd_tail_file_position and fluentd_tail_file_size.